### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/demo-server.yml
+++ b/.github/workflows/demo-server.yml
@@ -36,7 +36,7 @@ jobs:
         uses: actions/checkout@v2
       - name: Publish Universal Image to Registry
         id: universal
-        uses: elgohr/Publish-Docker-Github-Action@master
+        uses: elgohr/Publish-Docker-Github-Action@v5
         env:
           serviceWorker: false
           displayVersion: ${{ github.event.after }}

--- a/.github/workflows/reports.yml
+++ b/.github/workflows/reports.yml
@@ -28,7 +28,7 @@ jobs:
 
       - name: Publish Reports Image to Registry
         id: reports
-        uses: elgohr/Publish-Docker-Github-Action@master
+        uses: elgohr/Publish-Docker-Github-Action@v5
         with:
           name: reports
           username: ${{ secrets.DOCKER_REGISTRY_USERNAME }}


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore